### PR TITLE
fix: test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 /bazel-*
 api
+cover.html

--- a/ch3/Makefile
+++ b/ch3/Makefile
@@ -25,9 +25,10 @@ build:
 test:
 	go test ./... -coverprofile=coverage.out
 
-coverage:
-	go tool cover -func coverage.out \
-	| grep "total:" | awk '{print ((int($$3) > 80) != 1) }'
+coverage: test
+	go tool cover -func coverage.out | \
+	awk '/total:/ {print ((int($$3) > 80) != 1) }'
 
 report:
 	go tool cover -html=coverage.out -o cover.html
+


### PR DESCRIPTION
Testing the coverage was not generating errors with the coverage is below the target:

```
~/Projects/hello-api/ch3$ go tool cover -func coverage.out | awk '/total:/ {print $0;exit ((int($3) > 80) != 1)}'
total:								(statements)		84.0%
~/Projects/hello-api/ch3$ echo $?
0
~/Projects/hello-api/ch3$ go tool cover -func coverage.out | awk '/total:/ {print $0;exit ((int($3) > 90) != 1)}'
total:								(statements)		84.0%
~/Projects/hello-api/ch3$ echo $?
1
```

Also made an improvement to avoid using `grep` without need.